### PR TITLE
don't truncate returned samples in Simple

### DIFF
--- a/gosamplerate.go
+++ b/gosamplerate.go
@@ -22,6 +22,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"math"
 )
 
 // Src struct holding the data for the full API
@@ -130,7 +131,13 @@ func Simple(dataIn []float32, ratio float64, channels int, converterType int) ([
 	dataInLength := len(dataIn)
 
 	inputBuffer := make([]C.float, dataInLength)
-	outputBuffer := make([]C.float, dataInLength*int(ratio)+20) // add some margin
+	n := int(math.Ceil(ratio))
+	if n <= 0 {
+		// hack to make sure we can get the pointer to an underlying
+		// array.
+		n = 1
+	}
+	outputBuffer := make([]C.float, dataInLength*n)
 
 	// copy data into input buffer
 	for i, el := range dataIn {

--- a/gosamplerate_test.go
+++ b/gosamplerate_test.go
@@ -105,6 +105,25 @@ func TestSimple(t *testing.T) {
 	}
 }
 
+func TestSimpleLessThanOne(t *testing.T) {
+	var input []float32
+	for i := 0; i < 10; i++ {
+		input = append(input, 0.1, -0.5, 0.3, 0.4, 0.1)
+	}
+	expectedOutput := []float32{0.1, -0.5, 0.4, 0.1, 0.3, 0.1, -0.5, 0.4, 0.1, 0.3, 0.1, -0.5, 0.4, 0.1, 0.3, 0.1, -0.5, 0.4, 0.1, 0.3, 0.1, -0.5, 0.4, 0.1, 0.3}
+
+	output, err := Simple(input, 0.5, 1, SRC_LINEAR)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(output, expectedOutput) {
+		t.Log("input", input)
+		t.Log("output", output)
+		t.Fatal("unexpected output")
+	}
+}
+
 func TestSimpleError(t *testing.T) {
 
 	input := []float32{0.1, 0.9}


### PR DESCRIPTION
Instead of truncating the ratio, round it upwards to make sure we always
allocate enough samples. This gets rid of the "margin" (which wasn't
large enough for all cases, anyway), and supports ratios less than 1,
which previously only returned up to 20 samples.