### PR TITLE
make golden tests more robust

### DIFF
--- a/gosamplerate_test.go
+++ b/gosamplerate_test.go
@@ -98,9 +98,10 @@ func TestSimple(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(output, expectedOutput) {
+	if !closeEnough(output, expectedOutput) {
 		t.Log("input", input)
 		t.Log("output", output)
+		t.Log("expectedOutput", expectedOutput)
 		t.Fatal("unexpected output")
 	}
 }
@@ -294,4 +295,16 @@ func TestErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func closeEnough(a, b []float32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v-b[i] > 0.00001 {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
There was a floating point near-miss on my system.

--- FAIL: TestSimple (0.00s)
    gosamplerate_test.go:102: input [0.1 -0.5 0.3 0.4 0.1]
    gosamplerate_test.go:103: output [0.1 0.1 -0.1 -0.5 0.033333343 0.33333334 0.4 0.2]
    gosamplerate_test.go:104: unexpected output
FAIL